### PR TITLE
Refatoração do WebsitePageContext

### DIFF
--- a/pages/app/login.js
+++ b/pages/app/login.js
@@ -3,24 +3,17 @@ import Link from '../../src/components/commons/Link';
 import Box from '../../src/components/foundation/Layout/Box';
 import Grid from '../../src/components/foundation/Layout/Grid';
 import Text from '../../src/components/foundation/Text';
-import { WebsitePageContext } from '../../src/components/wrappers/WebsitePage';
 import websitePageHOC from '../../src/components/wrappers/WebsitePage/hoc';
 import Logo from '../../src/theme/Logo';
 import LoginForm from '../../src/components/patterns/FormLogin';
+import { usePageContext } from '../../src/components/wrappers/WebsitePage/context';
 
 function LoginScreen() {
-  const websitePageContext = React.useContext(WebsitePageContext);
+  const { toggleModalCadastro } = usePageContext();
+
   return (
-    <Grid.Container
-      display="flex"
-      flex="1"
-      alignItems="center"
-    >
-      <Grid.Row
-        flex="1"
-        alignItems="center"
-        justifyContent="center"
-      >
+    <Grid.Container display="flex" flex="1" alignItems="center">
+      <Grid.Row flex="1" alignItems="center" justifyContent="center">
         <Grid.Col
           display="flex"
           flexDirection="column"
@@ -36,27 +29,19 @@ function LoginScreen() {
             marginTop="37px"
             marginBottom="37px"
           >
-            <Link
-              href="/"
-              color="secondary.main"
-            >
+            <Link href="/" color="secondary.main">
               <Logo size="large" />
             </Link>
           </Box>
           <LoginForm />
-          <Text
-            variant="paragraph1"
-            tag="p"
-            color="tertiary.light"
-            textAlign="center"
-          >
+          <Text variant="paragraph1" tag="p" color="tertiary.light" textAlign="center">
             {'Não tem uma conta? '}
             <Link
               href="/"
               color="secondary.main"
               onClick={(event) => {
                 event.preventDefault();
-                websitePageContext.toggleModalCadastro();
+                toggleModalCadastro();
               }}
             >
               Cadastre-se
@@ -65,10 +50,7 @@ function LoginScreen() {
         </Grid.Col>
 
         <Grid.Col value={{ xs: 12, md: 6 }}>
-          <Box
-            display="flex"
-            justifyContent="center"
-          >
+          <Box display="flex" justifyContent="center">
             <img
               align="center"
               src="https://bootcamp-alura-01-git-modulo01.omariosouto.vercel.app/images/phones.png"

--- a/pages/faq/[slug].js
+++ b/pages/faq/[slug].js
@@ -2,13 +2,8 @@ import React from 'react';
 import FAQQuestionScreen from '../../src/components/screens/FAQQuestionScreen';
 import websitePageHOC from '../../src/components/wrappers/WebsitePage/hoc';
 
-function FAQInternaScreen({ category, question }) {
-  return (
-    <FAQQuestionScreen
-      question={question}
-      category={category}
-    />
-  );
+function FAQInternaScreen() {
+  return <FAQQuestionScreen />;
 }
 
 FAQInternaScreen.propTypes = FAQQuestionScreen.propTypes;
@@ -16,11 +11,12 @@ FAQInternaScreen.propTypes = FAQQuestionScreen.propTypes;
 export default websitePageHOC(FAQInternaScreen);
 
 export async function getStaticProps({ params }) {
-  const faqCategories = await fetch('https://instalura-api.vercel.app/api/content/faq')
-    .then(async (respostaDoServer) => {
+  const faqCategories = await fetch('https://instalura-api.vercel.app/api/content/faq').then(
+    async (respostaDoServer) => {
       const resposta = await respostaDoServer.json();
       return resposta.data;
-    });
+    },
+  );
 
   const dadosDaPagina = faqCategories.reduce((valorAcumulado, faqCategory) => {
     const foundQuestion = faqCategory.questions.find((question) => {
@@ -43,8 +39,10 @@ export async function getStaticProps({ params }) {
 
   return {
     props: {
-      category: dadosDaPagina.category,
-      question: dadosDaPagina.question,
+      contextValues: {
+        category: dadosDaPagina.category,
+        question: dadosDaPagina.question,
+      },
       pageWrapperProps: {
         seoProps: {
           headTitle: dadosDaPagina.question.title,
@@ -55,11 +53,12 @@ export async function getStaticProps({ params }) {
 }
 
 export async function getStaticPaths() {
-  const faqCategories = await fetch('https://instalura-api.vercel.app/api/content/faq')
-    .then(async (respostaDoServer) => {
+  const faqCategories = await fetch('https://instalura-api.vercel.app/api/content/faq').then(
+    async (respostaDoServer) => {
       const resposta = await respostaDoServer.json();
       return resposta.data;
-    });
+    },
+  );
 
   const paths = faqCategories.reduce((valorAcumulado, faqCategory) => {
     const questionsPaths = faqCategory.questions.map((question) => {
@@ -67,10 +66,7 @@ export async function getStaticPaths() {
       return { params: { slug: questionSlug } };
     });
 
-    return [
-      ...valorAcumulado,
-      ...questionsPaths,
-    ];
+    return [...valorAcumulado, ...questionsPaths];
   }, []);
 
   return {

--- a/pages/faq/index.js
+++ b/pages/faq/index.js
@@ -2,10 +2,8 @@ import React from 'react';
 import FAQScreen from '../../src/components/screens/FAQScreen';
 import websitePageHOC from '../../src/components/wrappers/WebsitePage/hoc';
 
-function FAQPage({ faqCategories }) {
-  return (
-    <FAQScreen faqCategories={faqCategories} />
-  );
+function FAQPage() {
+  return <FAQScreen />;
 }
 
 FAQPage.propTypes = FAQScreen.propTypes;
@@ -24,7 +22,9 @@ export async function getStaticProps() {
     .then((respostaConvertida) => respostaConvertida.data);
   return {
     props: {
-      faqCategories,
+      contextValues: {
+        faqCategories,
+      },
     }, // will be passed to the page component as props
   };
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,17 +3,15 @@ import Text from '../src/components/foundation/Text';
 import Button from '../src/components/commons/Button';
 import Box from '../src/components/foundation/Layout/Box';
 import Grid from '../src/components/foundation/Layout/Grid';
-import { WebsitePageContext } from '../src/components/wrappers/WebsitePage';
 import websitePageHOC from '../src/components/wrappers/WebsitePage/hoc';
+import { usePageContext } from '../src/components/wrappers/WebsitePage/context';
 
 // eslint-disable-next-line react/prop-types
 function HomeScreen() {
-  const websitePageContext = React.useContext(WebsitePageContext);
+  const { toggleModalCadastro } = usePageContext();
 
   return (
-    <Box
-      flex="1"
-    >
+    <Box flex="1">
       <Grid.Container
         marginTop={{
           xs: '32px',
@@ -56,8 +54,8 @@ function HomeScreen() {
                 md: '16px 0 40px 0',
               }}
             >
-              Lorem Ipsum is simply dummy text of the printing and typesetting industry.
-              Lorem Ipsum has been the industrys standard dummy text ever since the 1500s.
+              Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
+              has been the industrys standard dummy text ever since the 1500s.
             </Text>
 
             <Button
@@ -67,14 +65,12 @@ function HomeScreen() {
                 md: 'initial',
               }}
               display="block"
-              onClick={() => websitePageContext.toggleModalCadastro()}
+              onClick={() => toggleModalCadastro()}
             >
               Cadastrar
             </Button>
           </Grid.Col>
-          <Grid.Col
-            value={{ xs: 12, md: 6 }}
-          >
+          <Grid.Col value={{ xs: 12, md: 6 }}>
             <img
               alt="Imagem de celular com páginas internas do projeto com o perfil do Cage"
               style={{ display: 'block', margin: 'auto' }}

--- a/pages/sobre/index.js
+++ b/pages/sobre/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+// import PropTypes from 'prop-types';
 import AboutScreen, { getContent } from '../../src/components/screens/AboutScreen';
 import websitePageHOC from '../../src/components/wrappers/WebsitePage/hoc';
 
@@ -8,15 +8,15 @@ export async function getStaticProps({ preview }) {
 
   return {
     props: {
-      messages,
+      contextValues: {
+        messages,
+      },
     },
   };
 }
 
-function AboutPage({ messages }) {
-  return (
-    <AboutScreen messages={messages} />
-  );
+function AboutPage() {
+  return <AboutScreen />;
 }
 
 export default websitePageHOC(AboutPage, {
@@ -27,7 +27,7 @@ export default websitePageHOC(AboutPage, {
   },
 });
 
-AboutPage.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
-  messages: PropTypes.object.isRequired,
-};
+// AboutPage.propTypes = {
+//   // eslint-disable-next-line react/forbid-prop-types
+//   messages: PropTypes.object.isRequired,
+// };

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -6,7 +6,7 @@ import Link from '../../commons/Link';
 import propToStyle from '../../../theme/utils/propToStyle';
 import breakpointsMedia from '../../../theme/utils/breakpointsMedia';
 
-import { WebsitePageContext } from '../../wrappers/WebsitePage/context';
+import { usePageContext } from '../../wrappers/WebsitePage/context';
 
 export const TextStyleVariantsMap = {
   title: css`
@@ -59,10 +59,10 @@ const TextBase = styled.span`
 export default function Text({
   tag, variant, children, href, cmsKey, ...props
 }) {
-  const websitePageContext = React.useContext(WebsitePageContext);
+  const { getCMSContent } = usePageContext();
 
   const componentContent = cmsKey
-    ? websitePageContext.getCMSContent(cmsKey)
+    ? getCMSContent(cmsKey)
     : children;
 
   if (href) {

--- a/src/components/screens/AboutScreen/index.js
+++ b/src/components/screens/AboutScreen/index.js
@@ -1,34 +1,20 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+// import PropTypes from 'prop-types';
 import Box from '../../foundation/Layout/Box';
 import Grid from '../../foundation/Layout/Grid';
 import Text from '../../foundation/Text';
+import { usePageContext } from '../../wrappers/WebsitePage/context';
 
 export { getContent } from './getContent';
 
-function AboutScreen({ messages }) {
+function AboutScreen() {
+  const { messages } = usePageContext();
   return (
-    <Box
-      display="flex"
-      flexDirection="column"
-      flex={1}
-    >
+    <Box display="flex" flexDirection="column" flex={1}>
       <Grid.Container>
-        <Grid.Row
-          marginTop={{ xs: '32px', md: '120px' }}
-          flex="1"
-        >
-          <Grid.Col
-            value={{ xs: 12, md: 6, lg: 6 }}
-            offset={{ md: 2 }}
-            flex={1}
-          >
-            <Text
-              variant="title"
-              tag="h2"
-              color="tertiary.main"
-              cmsKey="pageSobre.pageTitle"
-            />
+        <Grid.Row marginTop={{ xs: '32px', md: '120px' }} flex="1">
+          <Grid.Col value={{ xs: 12, md: 6, lg: 6 }} offset={{ md: 2 }} flex={1}>
+            <Text variant="title" tag="h2" color="tertiary.main" cmsKey="pageSobre.pageTitle" />
 
             <Box
               dangerouslySetInnerHTML={{
@@ -42,9 +28,9 @@ function AboutScreen({ messages }) {
   );
 }
 
-AboutScreen.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
-  messages: PropTypes.object.isRequired,
-};
+// AboutScreen.propTypes = {
+//   // eslint-disable-next-line react/forbid-prop-types
+//   messages: PropTypes.object.isRequired,
+// };
 
 export default AboutScreen;

--- a/src/components/screens/FAQQuestionScreen/index.js
+++ b/src/components/screens/FAQQuestionScreen/index.js
@@ -1,19 +1,15 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useTheme } from 'styled-components';
 import Grid from '../../foundation/Layout/Grid';
 import Box from '../../foundation/Layout/Box';
 import Text from '../../foundation/Text';
+import { usePageContext } from '../../wrappers/WebsitePage/context';
 
-export default function FAQQuestionScreen({ category, question }) {
+export default function FAQQuestionScreen() {
+  const { category, question } = usePageContext();
   const theme = useTheme();
   return (
-    <Box
-      display="flex"
-      flexDirection="column"
-      flex="1"
-      justifyContent="center"
-    >
+    <Box display="flex" flexDirection="column" flex="1" justifyContent="center">
       <Grid.Container
         flex="1"
         marginTop={{
@@ -27,15 +23,8 @@ export default function FAQQuestionScreen({ category, question }) {
             md: 'row',
           }}
         >
-          <Grid.Col
-            offset={{ sm: 0, lg: 1 }}
-            value={{ xs: 12, md: 4, lg: 4 }}
-          >
-            <Text
-              variant="title"
-              color="tertiary.main"
-              marginBottom="25px"
-            >
+          <Grid.Col offset={{ sm: 0, lg: 1 }} value={{ xs: 12, md: 4, lg: 4 }}>
+            <Text variant="title" color="tertiary.main" marginBottom="25px">
               Artigos
               <br />
               Relacionados
@@ -69,17 +58,14 @@ export default function FAQQuestionScreen({ category, question }) {
               md: '0',
             }}
           >
-            <Text
-              variant="title"
-              color="tertiary.main"
-            >
+            <Text variant="title" color="tertiary.main">
               {question.title}
             </Text>
             <Text
               as="p"
               variant="paragraph1"
               color="tertiary.light"
-                          // eslint-disable-next-line react/no-danger
+              // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{ __html: question.description }}
             />
           </Grid.Col>
@@ -89,15 +75,17 @@ export default function FAQQuestionScreen({ category, question }) {
   );
 }
 
-FAQQuestionScreen.propTypes = {
-  category: PropTypes.shape({
-    title: PropTypes.string,
-    questions: PropTypes.arrayOf(PropTypes.shape({
-      title: PropTypes.string,
-    })),
-  }).isRequired,
-  question: PropTypes.shape({
-    title: PropTypes.string,
-    description: PropTypes.string,
-  }).isRequired,
-};
+// FAQQuestionScreen.propTypes = {
+//   category: PropTypes.shape({
+//     title: PropTypes.string,
+//     questions: PropTypes.arrayOf(
+//       PropTypes.shape({
+//         title: PropTypes.string,
+//       }),
+//     ),
+//   }).isRequired,
+//   question: PropTypes.shape({
+//     title: PropTypes.string,
+//     description: PropTypes.string,
+//   }).isRequired,
+// };

--- a/src/components/screens/FAQScreen/index.js
+++ b/src/components/screens/FAQScreen/index.js
@@ -1,94 +1,70 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Text from '../../foundation/Text';
 import Box from '../../foundation/Layout/Box';
 import Grid from '../../foundation/Layout/Grid';
+import { usePageContext } from '../../wrappers/WebsitePage/context';
 
-export default function FAQScreen({ faqCategories }) {
+export default function FAQScreen() {
+  const { faqCategories } = usePageContext();
+
   return (
-    <Box
-      display="flex"
-      flexDirection="column"
-      flex="1"
-    >
+    <Box display="flex" flexDirection="column" flex="1">
       <Grid.Container style={{ flex: 1 }}>
         <Grid.Row
           marginTop={{ xs: '32px', md: '100px' }}
           marginBottom={{ xs: '32px', md: '100px' }}
           justifyContent="center"
         >
-          <Grid.Col
-            value={{ xs: 12, md: 12 }}
-            flex={1}
-          >
-            <Text
-              variant="title"
-              tag="h2"
-              color="tertiary.main"
-              textAlign="center"
-            >
+          <Grid.Col value={{ xs: 12, md: 12 }} flex={1}>
+            <Text variant="title" tag="h2" color="tertiary.main" textAlign="center">
               Como podemos te ajudar?
             </Text>
           </Grid.Col>
         </Grid.Row>
-        <Grid.Row
-          alignItems="flex-start"
-          justifyContent="center"
-          flex="1"
-        >
-          {faqCategories && faqCategories.map((category) => (
-            <Grid.Col
-              value={{ xs: 12, md: 3 }}
-              flex={1}
-              key={category.title}
-            >
-              <Box
-                width="100%"
-              >
-                <Text
-                  variant="subTitle"
-                  tag="h2"
-                  color="tertiary.main"
-                  marginBottom="26px"
-                >
-                  {category.title}
-                </Text>
+        <Grid.Row alignItems="flex-start" justifyContent="center" flex="1">
+          {faqCategories
+            && faqCategories.map((category) => (
+              <Grid.Col value={{ xs: 12, md: 3 }} flex={1} key={category.title}>
+                <Box width="100%">
+                  <Text variant="subTitle" tag="h2" color="tertiary.main" marginBottom="26px">
+                    {category.title}
+                  </Text>
 
-                <Box
-                  as="ul"
-                  padding="0"
-                  listStyle="none"
-                >
-                  {category.questions.map((question) => (
-                    <li key={question.title}>
-                      <Text
-                        href={`/faq/${question.slug}`}
-                        variant="paragraph1"
-                        tag="h2"
-                        color="tertiary.light"
-                      >
-                        {question.title}
-                      </Text>
-                    </li>
-                  ))}
+                  <Box as="ul" padding="0" listStyle="none">
+                    {category.questions.map((question) => (
+                      <li key={question.title}>
+                        <Text
+                          href={`/faq/${question.slug}`}
+                          variant="paragraph1"
+                          tag="h2"
+                          color="tertiary.light"
+                        >
+                          {question.title}
+                        </Text>
+                      </li>
+                    ))}
+                  </Box>
                 </Box>
-              </Box>
-            </Grid.Col>
-          ))}
+              </Grid.Col>
+            ))}
         </Grid.Row>
       </Grid.Container>
     </Box>
   );
 }
 
-FAQScreen.propTypes = {
-  faqCategories: PropTypes.arrayOf(PropTypes.shape({
-    title: PropTypes.string,
-    slug: PropTypes.string,
-    questions: PropTypes.arrayOf(PropTypes.shape({
-      title: PropTypes.string,
-      slug: PropTypes.string,
-      description: PropTypes.string,
-    })),
-  })).isRequired,
-};
+// FAQScreen.propTypes = {
+//   faqCategories: PropTypes.arrayOf(
+//     PropTypes.shape({
+//       title: PropTypes.string,
+//       slug: PropTypes.string,
+//       questions: PropTypes.arrayOf(
+//         PropTypes.shape({
+//           title: PropTypes.string,
+//           slug: PropTypes.string,
+//           description: PropTypes.string,
+//         }),
+//       ),
+//     }),
+//   ).isRequired,
+// };

--- a/src/components/wrappers/WebsitePage/context/index.js
+++ b/src/components/wrappers/WebsitePage/context/index.js
@@ -1,7 +1,17 @@
 /* eslint-disable import/prefer-default-export */
-import React from 'react';
+import React, { useContext } from 'react';
 
-export const WebsitePageContext = React.createContext({
-  toggleModalCadastro: () => {},
-  getCMSContent: (cmsKey) => cmsKey,
-});
+const WebsitePageContext = React.createContext();
+
+// eslint-disable-next-line react/prop-types
+export const WebsitePageContextProvider = ({ value, children }) => (
+  <WebsitePageContext.Provider value={value}>{children}</WebsitePageContext.Provider>
+);
+
+export const usePageContext = () => {
+  const context = useContext(WebsitePageContext);
+
+  if (!context) throw new Error("You cant't use WebsitePageContext outside its Provider");
+
+  return context;
+};

--- a/src/components/wrappers/WebsitePage/hoc/index.js
+++ b/src/components/wrappers/WebsitePage/hoc/index.js
@@ -9,15 +9,22 @@ export default function websitePageHOC(
   PageComponent,
   { pageWrapperProps } = { pageWrapperProps: {} },
 ) {
-  return (props) => (
-    <WebsiteGlobalProvider>
-      <WebsitePageWrapper
-        {...pageWrapperProps}
-        {...props.pageWrapperProps}
-        messages={props.messages}
-      >
-        <PageComponent {...props} />
-      </WebsitePageWrapper>
-    </WebsiteGlobalProvider>
-  );
+  return (props) => {
+    // passa pro PageComponent as props que não sejam
+    // contextValues ou pageWrapperProps
+    // OBS: a renomeção para pageWrapperPropsFromProps foi só pra
+    // evitar o conflito da variavel ja definida na linha 10
+    const { contextValues, pageWrapperProps: pageWrapperPropsFromProps, ...rest } = props;
+    return (
+      <WebsiteGlobalProvider>
+        <WebsitePageWrapper
+          {...pageWrapperProps}
+          {...pageWrapperPropsFromProps}
+          contextValues={contextValues}
+        >
+          <PageComponent {...rest} />
+        </WebsitePageWrapper>
+      </WebsiteGlobalProvider>
+    );
+  };
 }

--- a/src/components/wrappers/WebsitePage/index.js
+++ b/src/components/wrappers/WebsitePage/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import get from 'lodash/get';
@@ -8,58 +9,47 @@ import Modal from '../../commons/Modal';
 import Box from '../../foundation/Layout/Box';
 import FormCadastro from '../../patterns/FormCadastro';
 import SEO from '../../commons/SEO';
-import { WebsitePageContext } from './context';
+import { WebsitePageContextProvider } from './context';
 
-export { WebsitePageContext } from './context';
+export { WebsitePageContextProvider } from './context';
 
 export default function WebsitePageWrapper({
   children,
   seoProps,
   pageBoxProps,
   menuProps,
-  messages,
+  contextValues,
 }) {
   const [isModalOpen, setModalState] = React.useState(false);
 
   return (
-    <WebsitePageContext.Provider
+    <WebsitePageContextProvider
       value={{
         teste: true,
         toggleModalCadastro: () => {
           setModalState(!isModalOpen);
         },
-        getCMSContent: (cmsKey) => get(messages, cmsKey),
+        getCMSContent: (cmsKey) => get(contextValues.messages, cmsKey),
+        // faqCategories,
+        ...contextValues,
       }}
     >
-      <SEO
-        {...seoProps}
-      />
+      <SEO {...seoProps} />
 
-      <Box
-        display="flex"
-        flex="1"
-        flexDirection="column"
-        {...pageBoxProps}
-      >
+      <Box display="flex" flex="1" flexDirection="column" {...pageBoxProps}>
         <Modal
           isOpen={isModalOpen}
           onClose={() => {
             setModalState(false);
           }}
         >
-          {(propsDoModal) => (
-            <FormCadastro propsDoModal={propsDoModal} />
-          )}
+          {(propsDoModal) => <FormCadastro propsDoModal={propsDoModal} />}
         </Modal>
-        {menuProps.display && (
-        <Menu
-          onCadastrarClick={() => setModalState(true)}
-        />
-        )}
+        {menuProps.display && <Menu onCadastrarClick={() => setModalState(true)} />}
         {children}
         <Footer />
       </Box>
-    </WebsitePageContext.Provider>
+    </WebsitePageContextProvider>
   );
 }
 

--- a/src/components/wrappers/WebsiteUserPage/index.js
+++ b/src/components/wrappers/WebsiteUserPage/index.js
@@ -6,7 +6,7 @@ import Modal from '../../commons/Modal';
 import Box from '../../foundation/Layout/Box';
 import FormCadastro from '../../patterns/FormCadastro';
 import SEO from '../../commons/SEO';
-import { WebsitePageContext } from '../WebsitePage/context';
+import { WebsitePageContextProvider } from '../WebsitePage/context';
 
 // export { WebsitePageContext } from './context';
 
@@ -19,7 +19,7 @@ export default function WebsiteUserPageWrapper({
   const [isModalOpen, setModalState] = React.useState(false);
 
   return (
-    <WebsitePageContext.Provider
+    <WebsitePageContextProvider
       value={{
         teste: true,
         toggleModalCadastro: () => {
@@ -55,7 +55,7 @@ export default function WebsiteUserPageWrapper({
         )}
         {children}
       </Box>
-    </WebsitePageContext.Provider>
+    </WebsitePageContextProvider>
   );
 }
 


### PR DESCRIPTION
1. 8b9fbfd
- Refatorar `WebsitePageContext` para um hook `usePageContext`. Desta forma é necessário importar apenas o `usePageContext` para pegar os valores com _desctructuring_. Não é mais necessário importar `useContext` nem `WebsitePageContext`. Além disso o hook impede o uso do Context fora do seu Provider.
- Criar `WebsitePageContextProvider` para não precisar exportar mais `WebsitePageContext`.

2. 685af79
- Adicionar `contextValues` como props no `WebsitePageWrapper`.
-  Espalhar os valores de `contextValues` na prop `value` do `WebsitePageContextProvider`. Desta forma, todos os valores dentro de `contextValues` estarão acessíveis nos filhos através do `usePageContext`.

3. f4befc4
- Refatorar `WebsitePageHOC` para aceitar `contextValues`.

4. 55a24e7
- Refatorar retorno de `getServerSideProps` ou `getStaticProps` para retornar os valores referentes à contextos dentro de `contextValues`.

5. 3cd31cb
- Substituir todos os lugares que utilizavam `React.useContext(WebsitePageContext) por usePageContext()

6. ab00a60
- Pegar dados do `WebsitePageContext` através do `usePageContext` em vez de passá-los por props

ps: acho que meu prettier estragou a formatação de alguns arquivos, então algumas linhas, apesar de indicar mudanças, são apenas de formatação.